### PR TITLE
Update github after firestore migration

### DIFF
--- a/src/hooks/useCheatSheets.ts
+++ b/src/hooks/useCheatSheets.ts
@@ -6,7 +6,6 @@ import {
   updateCheatSheet, 
   deleteCheatSheet,
   getCheatSheetById,
-  migrateLocalStorageToFirestore 
 } from '@/lib/database';
 import type { CheatSheetData } from '@/lib/database';
 
@@ -54,8 +53,6 @@ export const useCheatSheets = () => {
     }
 
     try {
-      // Migrate localStorage data if exists
-      await migrateLocalStorageToFirestore();
       // Fetch latest data
       await loadCheatSheets();
     } catch (error) {

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -222,37 +222,3 @@ export const getCheatSheetById = async (id: string): Promise<CheatSheetData | nu
   
   return convertFirestoreDoc(docSnap);
 };
-
-// Migrate existing localStorage data to Firestore
-export const migrateLocalStorageToFirestore = async () => {
-  try {
-    const localData = localStorage.getItem('cheatsheets');
-    if (!localData) return;
-
-    const sheets = JSON.parse(localData);
-    const user = await ensureAnonymousSession();
-
-    for (const sheet of sheets) {
-      try {
-        await addDoc(collection(db, 'cheatSheets'), {
-          userId: user.uid,
-          title: sheet.title,
-          description: sheet.description,
-          category: sheet.category,
-          content: sheet.content,
-          isPublic: sheet.isPublic || false,
-          createdAt: serverTimestamp(),
-          updatedAt: serverTimestamp(),
-        });
-      } catch (error) {
-        console.error('Error migrating sheet:', sheet.title, error);
-      }
-    }
-
-    // Clear localStorage after successful migration
-    localStorage.removeItem('cheatsheets');
-    console.log('Successfully migrated localStorage data to Firestore');
-  } catch (error) {
-    console.error('Error during migration:', error);
-  }
-};


### PR DESCRIPTION
Remove `localStorage` migration logic to use Firestore as the sole database.

---
<a href="https://cursor.com/background-agent?bcId=bc-39d3854b-4fae-4cd0-9590-40222967ade4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-39d3854b-4fae-4cd0-9590-40222967ade4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

