### PR TITLE
Fix syntax error in CreateCheatSheet.tsx

### DIFF
--- a/src/pages/CreateCheatSheet.tsx
+++ b/src/pages/CreateCheatSheet.tsx
@@ -371,7 +371,6 @@ const CreateCheatSheet = () => {
                       </Card>
                     ))}
                   </div>
-                )
                 )}
               </CardContent>
             </Card>

--- a/src/pages/EditCheatSheet.tsx
+++ b/src/pages/EditCheatSheet.tsx
@@ -34,24 +34,11 @@ const EditCheatSheet = () => {
 	const [isLoading, setIsLoading] = useState(false);
 	const [isFetching, setIsFetching] = useState(true);
 	const displayItems = [...contentItems].slice().reverse();
-<<<<<<< HEAD
-	const sensors = useSensors(
-		useSensor(MouseSensor, { activationConstraint: { distance: 6 } }),
-		useSensor(TouchSensor, { activationConstraint: { delay: 150, tolerance: 5 } })
-	);
-	const handleDragEnd = (event: DragEndEvent) => {
-		const { active, over } = event;
-		if (!over || active.id === over.id) return;
-		const oldIndex = displayItems.findIndex((i) => i.id === active.id);
-		const newIndex = displayItems.findIndex((i) => i.id === over.id);
-		const newDisplay = arrayMove(displayItems, oldIndex, newIndex);
-=======
 	const handlePositionChange = (id: string, newPositionOneBased: number) => {
 		const oldIndex = displayItems.findIndex((i) => i.id === id);
 		const newIndex = Math.max(0, Math.min(displayItems.length - 1, newPositionOneBased - 1));
 		if (oldIndex === -1 || oldIndex === newIndex) return;
 		const newDisplay = moveItem(displayItems, oldIndex, newIndex);
->>>>>>> cursor/ubah-urutan-konten-cheat-sheet-dengan-drag-and-drop-0f66
 		const newContent = newDisplay.slice().reverse();
 		setContentItems(newContent);
 	};
@@ -417,14 +404,13 @@ const EditCheatSheet = () => {
 															placeholder="Enter section title"
 														/>
 													</div>
-													{renderEditor(item)}
-												</CardContent>
-											</Card>
-										))}
-									</div>
-								)
-								)}
-							</CardContent>
+																									{renderEditor(item)}
+											</CardContent>
+										</Card>
+									))}
+								</div>
+							)}
+						</CardContent>
 						</Card>
 					</div>
 				</div>


### PR DESCRIPTION
Fixes Vercel deployment build errors by correcting JSX syntax and resolving a merge conflict in content rendering logic.

The build was failing due to an "Expected '}' but found ')'" error caused by an extraneous closing parenthesis in JSX conditional rendering. Additionally, a merge conflict in `EditCheatSheet.tsx` prevented successful compilation, which has been resolved by retaining the position-based item reordering.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3cd6e49-a2aa-4363-9655-be9c87fc4d65">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c3cd6e49-a2aa-4363-9655-be9c87fc4d65">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

