### PR TITLE
fix(pdf-export): Preserve bold formatting in code blocks

### DIFF
--- a/src/utils/pdfExport.tsx
+++ b/src/utils/pdfExport.tsx
@@ -11,6 +11,16 @@ Font.register({
   ]
 });
 
+Font.register({
+  family: 'Courier',
+  fonts: [
+    { fontWeight: 'normal' },
+    { fontWeight: 'bold' },
+    { fontStyle: 'italic' },
+    { fontWeight: 'bold', fontStyle: 'italic' },
+  ]
+});
+
 interface ContentItem {
   id: string;
   type: 'text' | 'math' | 'code';
@@ -480,17 +490,28 @@ const CheatSheetPDF = ({ data, columns }: { data: CheatSheetData; columns: PdfCo
                           </View>
                         )}
                        
-                       {item.type === 'math' && (
-                         <Text style={styles.mathContent}>
-                           {renderMathToText(stripHtml(item.content))}
-                         </Text>
-                       )}
-                       
-                       {item.type === 'code' && (
-                         <Text style={styles.codeContent}>
-                           {stripHtml(item.content)}
-                         </Text>
-                       )}
+                        {item.type === 'math' && (
+                          <Text style={styles.mathContent}>
+                            {renderMathToText(stripHtml(item.content))}
+                          </Text>
+                        )}
+
+                        {item.type === 'code' && (
+                          <Text style={styles.codeContent}>
+                            {parseHtmlContent(item.content).map((segment, segIndex) => {
+                              const style: any = {};
+                              if (segment.bold) style.fontWeight = 'bold';
+                              if (segment.italic) style.fontStyle = 'italic';
+                              if (segment.color) style.color = segment.color;
+
+                              return (
+                                <Text key={segIndex} style={style}>
+                                  {segment.text}
+                                </Text>
+                              );
+                            })}
+                          </Text>
+                        )}
                      </View>
                    </View>
                   ))}


### PR DESCRIPTION
This commit fixes an issue where bold text in code blocks was not being rendered in the exported PDF.

The `stripHtml` function was being used on code content, which removed all HTML tags, including those for bold text. This has been replaced with the `parseHtmlContent` function, which preserves the formatting.

Additionally, the `Courier` font has been registered with its bold and italic variants to ensure that `@react-pdf/renderer` can correctly apply the styles.